### PR TITLE
:bug: fix cache regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "alfred_gitmoji"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "alfred_workflow_rs",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "alfred_workflow_rs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c306988a991853d2fe7215a2b283b0d6d4874e0c30cb4cac76e674326d8514"
+checksum = "d9b90a12b4d637223d6793f34ec47e9e469514f0edb940645facac278c529d1d"
 dependencies = [
  "cached",
  "md5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 publish = false
 
 [dependencies]
-alfred_workflow_rs = "1.0"
+alfred_workflow_rs = "1.0.1"
 anyhow = "1.0"
 dotenvy = "0.15"
 rayon = "1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alfred_gitmoji"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Search Gitmoji with Alfred."

--- a/src/tests/main.rs
+++ b/src/tests/main.rs
@@ -5,12 +5,26 @@ use anyhow::anyhow;
 
 use super::*;
 
+fn cached_search_result() -> SearchResult {
+    SearchResult {
+        object_id: "bug".to_owned(),
+        emoji: "🐛".to_owned(),
+        entity: "&#x1f41b;".to_owned(),
+        code: ":bug:".to_owned(),
+        description: "Fix a bug".to_owned(),
+        name: "bug".to_owned(),
+        semver: Some("patch".to_owned()),
+    }
+}
+
 #[test]
 fn file_cache_hit_bypasses_algolia_and_image_resolution() -> Result<()> {
     let directory = tempfile::tempdir()?;
     let mut cached_workflow = Workflow::with_file_cache(FileCache::with_path(directory.path()));
     cached_workflow.set_cache_key(Some("cached-query"));
-    cached_workflow.add_item(Item::new("cached result"))?;
+    let cached_item =
+        items_from_results(&[cached_search_result()], &[None::<&std::path::Path>])?.remove(0);
+    cached_workflow.add_item(cached_item.clone())?;
 
     let mut workflow = Workflow::with_file_cache(FileCache::with_path(directory.path()));
     let algolia_calls = Cell::new(0);
@@ -35,7 +49,7 @@ fn file_cache_hit_bypasses_algolia_and_image_resolution() -> Result<()> {
 
     assert_eq!(algolia_calls.get(), 0);
     assert_eq!(image_resolution_calls.get(), 0);
-    assert_eq!(workflow.get_items()?.len(), 1);
+    assert_eq!(workflow.get_items()?.items(), &[cached_item]);
 
     Ok(())
 }


### PR DESCRIPTION
This pull request includes a version bump and dependency update, as well as improvements to the test for file cache behavior in the workflow. The main changes are:

Dependency and version updates:
* Bumped the crate version in `Cargo.toml` from `1.4.1` to `1.4.2` and updated the `alfred_workflow_rs` dependency from `1.0` to `1.0.1`.

Test improvements:
* Added a `cached_search_result()` helper function in `src/tests/main.rs` to provide a consistent test object for cache-related tests.
* Updated the cache test to use the new helper and to compare the actual cached item structure instead of just the item count, making the test more robust. [[1]](diffhunk://#diff-0033c8748526498719d37e931988fd4e20a219ad6669f5938afd9792d69f0e3aR8-R27) [[2]](diffhunk://#diff-0033c8748526498719d37e931988fd4e20a219ad6669f5938afd9792d69f0e3aL38-R52)